### PR TITLE
Added ViolentMonkey context types

### DIFF
--- a/context/violentmonkey.d.ts
+++ b/context/violentmonkey.d.ts
@@ -1,0 +1,216 @@
+/**
+ * Exports ViolentMonkey's API types
+ */
+
+import {
+  Info,
+  Serializable,
+  ListenerID,
+  ListenerCallback,
+  MenuCommandCallback,
+  TabControl,
+  OpenTabOptions,
+  MenuCommandID,
+  MenuCaption,
+  NotificationControl,
+  RequestDetails,
+  RequestControl,
+  DownloadOptions,
+  HTMLAttributeMap,
+  OptionalNode
+} from "./violentmonkey/GM";
+
+/* eslint-disable camelcase */
+declare global {
+  const unsafeWindow: typeof window;
+
+  /** An object that exposes information about the current userscript. */
+  const GM_info: Info;
+
+  /**
+   * Retrieves a value for current script from storage.
+   * @param key {string} - The name for value to load.
+   * @param defaultValue {T} - The default value to return if no value exists in the storage.
+   */
+  function GM_getValue<T>(key: string, defaultValue: T): T | undefined;
+
+  /**
+   * Sets a key / value pair for current script to storage.
+   * @param key {string} - The unique name for value within this script
+   * @param value {T} - The value to be stored, which must be JSON serializable (string, number, boolean, null, or an array/object consisting of these types) so for example you can't store DOM elements or objects with cyclic dependencies.
+   */
+  function GM_setValue<T extends Serializable>(key: string, value: T): void;
+
+  /**
+   * Deletes an existing key / value pair for current script from storage.
+   * @param key {string} - The unique name for value within this script.
+   */
+  function GM_deleteValue(key: string): void;
+
+  /** Returns an array of keys of all available values within this script. */
+  function GM_listValues(): string[];
+
+  /**
+   * Adds a change listener to the storage and returns the listener ID.
+   * @param name {string} - The value to observe
+   * @param callback {ListenerCallback<T>} - The function to run when the observed value changes.
+   */
+  function GM_addValueChangeListener<T>(
+    name: string,
+    callback: ListenerCallback<T>
+  ): ListenerID;
+
+  /**
+   * Removes a change listener by its ID.
+   * @param listenerId {ListenerID} - The ID of the listener.
+   */
+  function GM_removeValueChangeListener(listenerId: ListenerID): void;
+
+  /**
+   * Retrieves a text resource from the metadata block.
+   * @param name {string} - Name of a resource defined in the metadata block.
+   */
+  function GM_getResourceText(name: string): string | undefined;
+
+  /**
+   * Retrieves a `blob:` or `data:` URL of a resource from the metadata block.
+   *
+   * Note: when setting this URL as src or href of a DOM element,
+   * it may fail on some sites with a particularly strict CSP that forbids blob: or data: URLs.
+   * Such sites are rare though. The workaround in Chrome is to use GM_addElement,
+   * whereas in Firefox you'll have to disable CSP either globally via about:config
+   * or by using an additional extension that modifies HTTP headers selectively.
+   *
+   * @param name {string} - Name of a resource defined in the metadata block.
+   * @param isBlobUrl {boolean} - Optional parameter that decides whether to return a `blob:` or `data:` url.
+   */
+  function GM_getResourceURL(name: string, isBlobUrl: boolean): string | undefined;
+
+  /**
+   * Appends and returns an element with the specified attributes.
+   * @param parentNode {N | undefined | null} - The parent node to which the new node will be appended. It can be inside ShadowDOM: someElement.shadowRoot.
+   * @param tagName {string} -
+   * @param attributes {} -
+   */
+  function GM_addElement(
+    parentNode: OptionalNode,
+    tagName: keyof HTMLElementTagNameMap,
+    attributes: HTMLAttributeMap
+  ): HTMLElement;
+
+  /**
+   * Appends and returns a <style> element with the specified CSS.
+   * @param css {string} - The CSS to insert inside the style element.
+   */
+  function GM_addStyle(css: string): HTMLElement;
+
+  /**
+   * Opens URL in a new tab. Returns an object that can be used to control the new tab.
+   * @param url {string} - The URL to open in a new tab. URL relative to current page is also allowed. Note: Firefox does not support data URLs.
+   * @param options {} -
+   */
+  function GM_openInTab(url: string, options?: OpenTabOptions): TabControl;
+
+  /**
+   * Opens URL in a new tab using greasemonkey compatibility. Returns an object that can be used to control the new tab.
+   * @param url {string} - The URL to open in a new tab. URL relative to current page is also allowed. Note: Firefox does not support data URLs.
+   * @param openInBackground {boolean} -  Open the tab in background. Note, this is a reverse of the first usage method so for example true is the same as { active: false }.
+   */
+  function GM_openInTab(url: string, openInBackground: boolean): TabControl;
+
+  /**
+   * Registers a command in Violentmonkey popup menu.
+   * @param caption {string} - The name to show in the popup menu.
+   * @param onClick {MenuCommandCallback} - Fired when the command is clicked in the menu.
+   */
+  function GM_registerMenuCommand(caption: MenuCaption, onClick: MenuCommandCallback): MenuCommandID;
+
+  /**
+   * Unregisters a command which has been registered to Violentmonkey popup menu.
+   * @param caption {string} - The name of command to unregister.
+   */
+  function GM_unregisterMenuCommand(caption: MenuCaption): void;
+
+  /**
+   * Shows an HTML5 desktop notification.
+   * @param options {NotificationControl}
+   */
+  function GM_notification(options: NotificationOptions): NotificationControl;
+
+  /**
+   * Shows an HTML5 desktop notification using separate parameters, compatible with Greasemonkey.
+   * @param text - Main text of the notification.
+   * @param title - Title of the notification.
+   * @param image - URL of an image to show in the notification.
+   * @param onclick - Callback when the notification is clicked by user.
+   */
+  function GM_notification(text: string, title?: string, image?: string, onclick?: () => void): NotificationControl;
+
+  /**
+   * Sets data to system clipboard.
+   * @param data {string} The data to be copied to system clipboard.
+   * @param type {string|null|undefined} The MIME type of data to copy. (default text/plain)
+   */
+  function GM_setClipboard(data: string, type?: string): void;
+
+  /**
+   * Makes a request like XMLHttpRequest, with some special capabilities, not restricted by same-origin policy.
+   * @param details {RequestDetails<T>} - Options to define the request.
+   */
+  function GM_xmlhttpRequest<T>(
+    details: RequestDetails<T>
+  ): RequestControl;
+
+  /**
+   * Downloads a URL to a local file.
+   * @param options {DownloadOptions<T>} - Options to define the download request.
+   */
+  function GM_download<T>(
+    options: DownloadOptions<T>
+  ): RequestControl;
+
+  /**
+   * Downloads a URL to a local file.
+   * @param url {string} - The URL to download.
+   * @param name {string} - The filename to save to. Folders/subpaths aren't supported yet.
+   */
+  function GM_download(url: string, name: string): RequestControl;
+
+  const GM: {
+    info: Info;
+    addStyle(css: string): HTMLElement;
+    addElement(
+      parentNode: OptionalNode,
+      tagName: keyof HTMLElementTagNameMap,
+      attributes: HTMLAttributeMap
+    ): HTMLElement;
+    registerMenuCommand(
+      caption: MenuCaption,
+      onClick: MenuCommandCallback
+    ): MenuCommandID;
+    deleteValue(key: string): Promise<void>;
+    getResourceUrl(
+      name: string,
+      isBlobUrl?: boolean
+    ): Promise<string | undefined>;
+    getValue<T>(key: string, defaultValue: T): Promise<T | undefined>;
+    listValues(): Promise<string[]>;
+    notification(
+      textOrOptions: NotificationOptions | string,
+      title?: string,
+      image?: string,
+      onclick?: () => void
+    ): NotificationControl;
+    openInTab(
+      url: string,
+      optionsOrOpenInBackground: OpenTabOptions | boolean
+    ): TabControl;
+    setClipboard(data: string, type?: string): void;
+    setValue<T extends Serializable>(key: string, value: T): Promise<void>;
+    xmlHttpRequest<T>(
+      details: RequestDetails<T>
+    ): RequestControl;
+  };
+}
+
+export {};

--- a/context/violentmonkey/GM.d.ts
+++ b/context/violentmonkey/GM.d.ts
@@ -1,0 +1,219 @@
+type Arch = "arm" | "mips" | "mips64" | "x86-32" | "x86-64";
+type BrowserName = "chrome" | "firefox" | string;
+type OS = "android" | "cros" | "linux" | "mac" | "openbsd" | "win";
+
+type Platform = {
+    arch: Arch;
+    browserName: BrowserName;
+    browserVersion: string;
+    os: OS
+};
+
+type Resource = {
+    name: string;
+    url: string;
+}
+
+type Script = {
+    description: string;
+    excludes: string[];
+    includes: string[];
+    matches: string[];
+    name: string;
+    namespace: string;
+    resources: Resource[];
+    runAt: string;
+    version: string;
+}
+
+export type Info = {
+    /** A unique ID of the script. */
+    uuid: string;
+    /** The meta block of the script. */
+    scriptMetaStr: string;
+    /** Whether the script will be updated automatically. */
+    scriptWillUpdate: string;
+    /** The name of userscript manager, which should be the string Violentmonkey. */
+    scriptHandler: string;
+    /** Version of Violentmonkey. */
+    version: string;
+    /**
+     * Unlike navigator.userAgent, which can be overriden by other extensions/userscripts or by devtools in device-emulation mode,
+     * GM_info.platform is more reliable as the data is obtained in the background page of Violentmonkey using a specialized
+     * extension API (browser.runtime.getPlatformInfo and getBrowserInfo).
+     */
+    platform: Platform;
+    /** Contains structured fields from the Metadata Block. */
+    script: Script;
+    /** The injection mode of current script. See @inject-mode for more information. */
+    injectInto: string;
+};
+
+type Primitive = string | number | boolean | null;
+export type Serializable = Primitive | Array<Serializable> | { [key: string]: Serializable };
+
+/**
+ * Identifies an active value listener.
+ */
+export type ListenerID = string;
+
+/**
+ * A function that is executed when the associated key changes.
+ * @param key {string} - The name of the stored variable.
+ * @param oldValue {string} - The old value of the observed variable (undefined if it was created).
+ * @param newValue {string} - The new value of the observed variable (undefined if it was deleted).
+ * @param remote {boolean} - true if modified by the userscript instance of another tab or false for this script instance. Can be used by scripts of different browser tabs to communicate with each other.
+ */
+export type ListenerCallback<T> = (
+    key: string,
+    oldValue: T,
+    newValue: T,
+    remote: boolean
+) => unknown;
+
+export type OptionalNode = Node | Element | ShadowRoot | null | undefined;
+export type HTMLAttributeMap = {
+    [attribute: string]: string
+};
+
+export type OpenTabOptions = {
+    /**
+     * Make the new tab active (i.e. open in foreground). Defaults to `true`
+     */
+    active?: boolean;
+    /**
+     * Set tab's container in Firefox. See [GM_openInTab](https://violentmonkey.github.io/api/gm/#gm_openintab)
+     */
+    container?: 0 | 1 | 2;
+    /**
+     * Insert the new tab next to the current tab and set its "openerTab"
+     * so when it's closed the original tab will be focused automatically.
+     * When false or not specified, the usual browser behavior is to
+     * open the tab at the end of the tab list.
+     */
+    insert: boolean;
+    /**
+     * Pin the tab (i.e. show without a title at the beginning of the tab list).
+     */
+    pinned: boolean;
+};
+
+export type TabControl = {
+    onclose: (() => unknown) | null;
+    closed: boolean;
+    close(): unknown;
+};
+
+export type MenuCommandCallback = (event: MouseEvent | KeyboardEvent) => unknown;
+export type MenuCommandID = string;
+export type MenuCaption = string;
+
+export type NotificationOptions = {
+    // Main text of the notification.
+    text: string;
+    // Title of the notification.
+    title?: string;
+    // URL of an image to show in the notification.
+    image?: string;
+    // Callback when the notification is clicked by user.
+    onclick?: () => void;
+    // Callback when the notification is closed, either by user or by system.
+    ondone?: () => void;
+};
+
+export type NotificationControl = {
+    remove: () => Promise<void>;
+};
+
+export type Request<T> = {
+    status: number;
+    statusText: string;
+    readyState: number;
+    responseHeaders: string;
+    response: string | Blob | ArrayBuffer | Document | object | null;
+    responseText: string | undefined; // only provided when available
+    responseXML?: Document | null; // only provided when available
+    lengthComputable?: boolean; // only provided when available
+    loaded?: number; // only provided when available
+    total?: number; // only provided when available
+    finalUrl: string; // the final URL after redirection,
+    context: T; // the same context object you specified in details
+};
+
+export type RequestBase<T> = {
+    /**
+     * URL relative to current page is also allowed.
+     */
+    url: string;
+
+    /**
+     * User for authentication.
+     */
+    user?: string;
+
+    /**
+     * Password for authentication.
+     */
+    password?: string;
+
+    /**
+     * See [GM_xmlhttpRequest](https://violentmonkey.github.io/api/gm/#gm_xmlhttprequest)
+     */
+    headers?: { [header: string]: string };
+
+    /**
+     * Time to wait for the request, none by default.
+     */
+    timeout?: number;
+
+    /**
+     * Can be an object and will be assigned to context of the response object.
+     */
+    context?: T;
+
+    /**
+     * When set to true, no cookie will be sent with the request and since VM2.12.5 the response cookies will be ignored.
+     * When absent, an inverted value of Greasemonkey4-compatible withCredentials is used. Note that Violentmonkey sends cookies by default, like Tampermonkey, but unlike Greasemonkey4 (same-origin url only).
+     */
+    anonymous?: boolean;
+
+    // Each event handler is a function that accepts one argument responseObject
+    onabort?: <T>(responseObject: Request<T>) => void;
+    onerror?: <T>(responseObject: Request<T>) => void;
+    onload?: <T>(responseObject: Request<T>) => void;
+    onloadend?: <T>(responseObject: Request<T>) => void;
+    onloadstart?: <T>(responseObject: Request<T>) => void;
+    onprogress?: <T>(responseObject: Request<T>) => void;
+    onreadystatechange?: <T>(responseObject: Request<T>) => void;
+    ontimeout?: <T>(responseObject: Request<T>) => void;
+};
+
+export type RequestDetails<T> = RequestBase<T> & {
+    // Usually GET.
+    method?: string;
+    // A MIME type to specify with the request.
+    overrideMimeType?: string;
+
+    responseType?: "text" | "json" | "blob" | "arraybuffer" | "document";
+
+    // Data to send with the request, usually for POST and PUT requests.
+    data?:
+      | string
+      | ArrayBuffer
+      | Blob
+      | DataView
+      | FormData
+      | ReadableStream
+      | URLSearchParams;
+
+    // Send the data string as a blob. This is for compatibility with Tampermonkey/Greasemonkey, where only string type is allowed in data.
+    binary?: boolean;
+};
+
+export type RequestControl = {
+    abort: () => void;
+};
+
+export type DownloadOptions<T> = RequestBase<T> & {
+    name: string
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup-plugin-violent-monkey",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Prepends ViolentMonkey headers to your rollup bundle",
   "repository": "https://github.com/jensk-dev/rollup-plugin-violent-monkey",
   "license": "MIT",
@@ -17,7 +17,8 @@
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "context"
   ],
   "scripts": {
     "build": "unbuild",

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -51,6 +51,27 @@ const optionalBool = z.boolean().optional();
 
 export const primitiveField = optionalString.or(optionalUrl).or(optionalBool);
 
+/**
+ * Specifies when the script should be injected into the page.
+ */
+export const runAt = z.enum([
+  /**
+   * The script executes when DOMContentLoaded is fired.
+   * At this time, the basic HTML of the page is ready and other resources like images might still be on the way.
+   */
+  "document-end",
+  /**
+   * The script executes as soon as possible. There is no guarantee for the script to execute before other scripts in the page.
+   * Note: in Greasemonkey v3, the script may be ensured to execute even before HTML is loaded,
+   *       but this is impossible for Violentmonkey as a web extension.
+   */
+  "document-start",
+  /**
+   * The script executes after DOMContentLoaded is fired.
+   */
+  "document-idle"
+]);
+
 export const metadata = z.object({
   name: z.string().min(1),
   localizedName: localeMap,
@@ -68,7 +89,8 @@ export const metadata = z.object({
     z.string().min(1).regex(/^[^\s]+$/),
     z.string().url()
   ).optional(),
-  runAt: z.enum(["document-end", "document-start", "document-idle"]).optional(),
+  /** Decides when the script will be injected into the page. */
+  runAt: runAt.optional(),
   noframes: optionalBool,
   grants: grant.array().optional(),
   injectInto: z.enum(["page", "content", "auto"]).optional(),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "resolveJsonModule": true
   },
   "include": [
-    "src"
+    "src",
+    "context"
   ]
 }


### PR DESCRIPTION
Can be added to any implementing rollup project by adding a declaration file and referencing the context as shown in the below example:

Create `vm-env.d.ts` in your source directory root and add the following:
```ts
/// <reference types="rollup-plugin-violent-monkey/context/violentmonkey" />
```